### PR TITLE
Check glob path

### DIFF
--- a/lua/spectre/search/rg.lua
+++ b/lua/spectre/search/rg.lua
@@ -16,6 +16,9 @@ rg.init = function(_, config)
 end
 
 rg.get_path_args = function(_, path)
+    if #path == 0 then
+      return {}
+    end
     return  { '-g', path }
 end
 


### PR DESCRIPTION
On Windows this command will find nothing:

```bash
rg --color=never --no-heading --with-filename --line-number --column -g '' --ignore-case -- nvim
```

Option `-g` should be removed if not path present. Will not hurt on Linux either.

References #5.

But there also another issue with plenary: https://github.com/nvim-lua/plenary.nvim/issues/146.