### PR TITLE
feat(search):  Add the 'ag' engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ require('spectre').setup({
         -- show_option function
       }
     },
+    ['ag'] = {
+      cmd = "ag",
+      args = {
+        '--vimgrep',
+        '-s'
+      } ,
+      options = {
+        ['ignore-case'] = {
+          value= "-i",
+          icon="[I]",
+          desc="ignore case"
+        },
+        ['hidden'] = {
+          value="--hidden",
+          desc="hidden file",
+          icon="[H]"
+        },
+      },
+    },
   },
   replace_engine={
       ['sed']={

--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -103,6 +103,28 @@ local config = {
                 -- show_option function
             }
         },
+        ['ag'] = {
+            cmd = "ag",
+            -- default args
+            args = {
+                '--vimgrep',
+                '-s'
+            } ,
+            options = {
+                ['ignore-case'] = {
+                    value= "-i",
+                    icon="[I]",
+                    desc="ignore case"
+                },
+                ['hidden'] = {
+                    value="--hidden",
+                    desc="hidden file",
+                    icon="[H]"
+                },
+                -- you can put any option you want here it can toggle with
+                -- show_option function
+                },
+            },
     },
     replace_engine={
        ['sed']={

--- a/lua/spectre/config.lua
+++ b/lua/spectre/config.lua
@@ -121,10 +121,8 @@ local config = {
                     desc="hidden file",
                     icon="[H]"
                 },
-                -- you can put any option you want here it can toggle with
-                -- show_option function
-                },
             },
+        },
     },
     replace_engine={
        ['sed']={

--- a/lua/spectre/search/ag.lua
+++ b/lua/spectre/search/ag.lua
@@ -1,0 +1,21 @@
+local ag = {}
+
+ag.init = function(_, config)
+    config = vim.tbl_extend('force',{
+        cmd = "ag",
+        args = {
+            '--vimgrep',
+            '-s'
+        },
+    }, config or {})
+    return config
+end
+
+ag.get_path_args = function(_, path)
+    if #path == 0 then
+      return {}
+    end
+    return  { '-G', path }
+end
+
+return ag


### PR DESCRIPTION
I added config for `ag` the silver searcher. I specifically want this because ripgrep's `-g` glob flag that you use for paths disables all other ignore logic, including gitignore. `ag`'s `-G` flag does  not. 