### PR TITLE
feat: Implement support for supplying multiple paths.

### DIFF
--- a/lua/spectre/search/ag.lua
+++ b/lua/spectre/search/ag.lua
@@ -11,11 +11,16 @@ ag.init = function(_, config)
     return config
 end
 
-ag.get_path_args = function(_, path)
-    if #path == 0 then
+ag.get_path_args = function(_, paths)
+    if #paths == 0 then
       return {}
     end
-    return  { '-G', path }
+
+    local pattern = ""
+    for _, path in ipairs(paths) do
+        pattern = pattern .. path .. "|"
+    end
+    return  { '-G', pattern:sub(1, #pattern - 1) }
 end
 
 return ag

--- a/lua/spectre/search/base.lua
+++ b/lua/spectre/search/base.lua
@@ -3,6 +3,7 @@ local Job = require("plenary.job")
 local log = require('spectre._log')
 local MAX_LINE_CHARS = 255
 local utils = require('spectre.utils')
+local is_win = vim.api.nvim_call_function("has", {"win32"}) == 1
 local base = {}
 base.__index = base
 
@@ -12,11 +13,12 @@ base.__index = base
 local function scan_paths(s_path)
     local paths = {}
     local path = ""
+    local escape_char = is_win and "^" or "\\"
 
     local i = 1
     while i <= #s_path do
         local char = s_path:sub(i, i)
-        if char == "\\" then
+        if char == escape_char then
             -- Escape next character
             if i < #s_path then
                 i = i + 1
@@ -40,6 +42,7 @@ local function scan_paths(s_path)
         table.insert(paths, path)
     end
 
+    print(vim.inspect(paths))
     return paths
 end
 

--- a/lua/spectre/search/base.lua
+++ b/lua/spectre/search/base.lua
@@ -42,7 +42,6 @@ local function scan_paths(s_path)
         table.insert(paths, path)
     end
 
-    print(vim.inspect(paths))
     return paths
 end
 

--- a/lua/spectre/search/rg.lua
+++ b/lua/spectre/search/rg.lua
@@ -15,11 +15,17 @@ rg.init = function(_, config)
     return config
 end
 
-rg.get_path_args = function(_, path)
-    if #path == 0 then
+rg.get_path_args = function(_, paths)
+    if #paths == 0 then
       return {}
     end
-    return  { '-g', path }
+
+    local args = {}
+    for _, path in ipairs(paths) do
+        table.insert(args, "-g")
+        table.insert(args, path)
+    end
+    return  args
 end
 
 

--- a/tests/search/rg_spec.lua
+++ b/tests/search/rg_spec.lua
@@ -69,4 +69,28 @@ describe("[rg] search ", function()
 
     end)
 
+    it("search with multiple paths should not be empty", function()
+        local finish = false
+        local total = {}
+        local total_item = 0
+        local finder = rg:new({}, {
+            on_result = function(item)
+                table.insert(total, item)
+                total_item = total_item + 1
+            end,
+            on_finish = function()
+                finish = true
+            end
+        })
+        finder:search({
+            search_text = "(data|spectre)",
+            path = "**/rg_spec/*.txt **/sed_spec/*.txt"
+        })
+        vim.wait(time_wait, function()
+            return finish
+        end)
+        eq(4, total_item, "should have 4 items")
+
+    end)
+
 end)


### PR DESCRIPTION
This implements support for supplying multiple paths separated by whitespace. I made it respect `\` as an escape character on unix and caret `^` on windows, so if you need to supply a path with a space, you can do:

```
Unix:
some/path\ with/space

Windows:
some\path^ with\space
```

![image](https://user-images.githubusercontent.com/2786478/117361873-dbd12900-aeba-11eb-9ed5-ff39295a8de2.png)
