### PR TITLE
Make it more clear how to get help on the mappings

### DIFF
--- a/lua/spectre/ui.lua
+++ b/lua/spectre/ui.lua
@@ -137,7 +137,7 @@ end
 function M.render_header(opts)
     api.nvim_buf_clear_namespace(state.bufnr, config.namespace_header, 0, config.lnum_UI)
     local help_text = string.format(
-        "[Nvim Spectre] (Search by %s) %s (Replace by %s)  Mapping(?)",
+        "[Nvim Spectre] (Search by %s) %s (Replace by %s) (Press ? for mappings)",
         state.user_config.default.find.cmd,
         opts.live_update and '(Auto update)' or '',
         state.user_config.default.replace.cmd


### PR DESCRIPTION
I found it took me a while to notice the Mapping(?) command prompt. There is not much in the readme and I could not figure out how to actually write the changes at first. This change should make it more obvious how to get help on mappings while still keeping the header concise.