### PR TITLE
Minor comma misplaced in default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ require('spectre').setup({
       }
   },
   replace_vim_cmd = "cdo",
-  is_open_target_win = true --open file on opener window
-  is_insert_mode = false,  -- start open panel on is_insert_mode
+  is_open_target_win = true, --open file on opener window
+  is_insert_mode = false  -- start open panel on is_insert_mode
 })
 
 ```


### PR DESCRIPTION
Not sure if this was intentional but using the default config was throwing error because the comma was misplaced.

This was the error to be precise:

<code>
'}' expected (to close '{' at line 67) near 'is_insert_mode
'
</code>